### PR TITLE
Improve Dockerfile caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ ENV GO111MODULE=on
 ENV CGO_ENABLED=0
 ENV GOBIN=/bin
 RUN go install github.com/go-delve/delve/cmd/dlv@v1.8.2
-ADD https://github.com/spiffe/spire/releases/download/v1.2.2/spire-1.2.2-linux-x86_64-glibc.tar.gz .
-RUN tar xzvf spire-1.2.2-linux-x86_64-glibc.tar.gz -C /bin --strip=2 spire-1.2.2/bin/spire-server spire-1.2.2/bin/spire-agent
+RUN wget --no-verbose --output-document=- https://github.com/spiffe/spire/releases/download/v1.2.2/spire-1.2.2-linux-x86_64-glibc.tar.gz | tar xzf - -C /bin --strip=2 spire-1.2.2/bin/spire-server spire-1.2.2/bin/spire-agent
 
 FROM go as build
 WORKDIR /build


### PR DESCRIPTION
Evidently Docker's "ADD" command downloads the target to compute the checksum to see if it can use a cached layer. This means that the file is downloaded every build, which is wasteful, both of bandwidth and time.

This patch replaces the "ADD" and "RUN tar" with a RUN command that uses wget to fetch the file and pipes it into curl. Docker decides to use the cached layer without fetching the file so it's quite a bit faster and more bandwidth-efficient.

Signed-off-by: Toby Cabot <toby@acnodal.io>