### PR TITLE
Remove recvfd server from NSE

### DIFF
--- a/internal/pkg/imports/imports_linux.go
+++ b/internal/pkg/imports/imports_linux.go
@@ -19,7 +19,6 @@ import (
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/kernel"
-	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/recvfd"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/sendfd"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/null"
 	_ "github.com/networkservicemesh/sdk/pkg/networkservice/common/onidle"

--- a/main.go
+++ b/main.go
@@ -54,7 +54,6 @@ import (
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/kernel"
-	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/recvfd"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/sendfd"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/null"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/onidle"
@@ -208,7 +207,6 @@ func main() {
 			onidle.NewServer(ctx, cancel, config.IdleTimeout),
 			groupipam.NewServer(config.CidrPrefix),
 			policyroute.NewServer(newPolicyRoutesGetter(ctx, config.PBRConfigPath).Get),
-			recvfd.NewServer(),
 			mechanisms.NewServer(map[string]networkservice.NetworkServiceServer{
 				kernelmech.MECHANISM: kernel.NewServer(),
 				noop.MECHANISM:       null.NewServer(),


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/cmd-forwarder-vpp/issues/927

For endpoints it doesn't make sense to use `recvfd` server. Moreover, it can lead to errors.