### PR TITLE
Add interface names into NSM metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -207,7 +207,7 @@ func main() {
 			onidle.NewServer(ctx, cancel, config.IdleTimeout),
 			groupipam.NewServer(config.CidrPrefix),
 			policyroute.NewServer(newPolicyRoutesGetter(ctx, config.PBRConfigPath).Get),
-			mechanisms.NewServer(map[string]networkservice.NetworkServiceServer{
+			mechanisms.NewServerWithMetrics(map[string]networkservice.NetworkServiceServer{
 				kernelmech.MECHANISM: kernel.NewServer(),
 				noop.MECHANISM:       null.NewServer(),
 			}),


### PR DESCRIPTION
Task: https://github.com/networkservicemesh/sdk-vpp/issues/768

Add interface details for NSE:
![metrixNew drawio (1)](https://github.com/networkservicemesh/cmd-nsc/assets/10182393/eb496fec-1833-4c26-adf9-33eceaed5b2f)

Depends on: https://github.com/networkservicemesh/sdk/pull/1560