### PR TITLE
[qfix] Use the main ctx as a parent for signalCtx

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ func main() {
 	defer cancel()
 
 	signalCtx, _ := signal.NotifyContext(
-		context.Background(),
+		ctx,
 		os.Interrupt,
 		// More Linux signals here
 		syscall.SIGHUP,


### PR DESCRIPTION
## Issue
https://github.com/networkservicemesh/integration-k8s-kind/pull/934