### PR TITLE
Disable golangci-lint staticcheck SA1019

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,10 @@ linters-settings:
           - (github.com/sirupsen/logrus.FieldLogger).Warnf
           - (github.com/sirupsen/logrus.FieldLogger).Errorf
           - (github.com/sirupsen/logrus.FieldLogger).Fatalf
+  staticcheck:
+    checks:
+      - all
+      - '-SA1019'
   revive:
     confidence: 0.8
     rules:


### PR DESCRIPTION
## Issue 

https://github.com/networkservicemesh/deployments-k8s/issues/13105

## Description

This PR disables the `SA1019` rule from `staticcheck` in `golangci-lint`, which reports false-positive deprecation warnings. The warning refers to an unresolved deprecation in `grpc-go`, where no valid replacement (e.g., `NewClient`) currently exists.